### PR TITLE
HADOOP-16766: Increase timeout for RPCCallBenckmarik.testBenchmarkWithProto()

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCallBenchmark.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestRPCCallBenchmark.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 public class TestRPCCallBenchmark {
 
-  @Test(timeout=20000)
+  @Test(timeout=80000)
   public void testBenchmarkWithProto() throws Exception {
     int rc = ToolRunner.run(new RPCCallBenchmark(),
         new String[] {


### PR DESCRIPTION
Currently the timeout setting for org.apache.hadoop.ipc.TestRPCCallBenchmark.testBenchmarkWithProto() is 20 seconds, and on our ARM64 machine with 8 cores, it tooks about 60 seconds to finish the tests, so I want to propose to increase the timeout setting to 80 seconds, this will not affect tests on other platforms as they will finish in less than 20 secs.

